### PR TITLE
Fix #47: Active tests filter show duplicates when multiple drivers are active

### DIFF
--- a/server/src/main/webapp/benchmark/test/benchmark-test.js
+++ b/server/src/main/webapp/benchmark/test/benchmark-test.js
@@ -377,7 +377,26 @@
             $scope.showActiveTestDefs = function(value) {
                 if (value == true) {
                     TestDefService.getTestDefs(function(response) {
-                    $scope.defs = response;
+                    var uniqueDefs = [];    //this will contain the unique list of final custom test defs
+                    var isReleaseFound = function (releaseName) {
+                          for(var i = 0; i < uniqueDefs.length; i++){
+                            if(uniqueDefs[i]["release"]==releaseName){
+                                uniqueDefs[i]["count"] +=1;
+                                return true;
+                            }
+                          }
+                          return false;
+                    };
+                    
+                    for(var i = 0; i < response.length; i++){
+                        if (!isReleaseFound(response[i]["release"]))
+                        {
+                            response[i]["count"]= 1;
+                            uniqueDefs.push(response[i]);         
+                        }
+                    }
+                    
+                    $scope.defs = uniqueDefs;
                     if ($scope.defs.length == 0) {
                         $scope.nodefs = true;
                     } else {

--- a/server/src/main/webapp/benchmark/test/create.html
+++ b/server/src/main/webapp/benchmark/test/create.html
@@ -28,7 +28,7 @@
             <label for="pickTestDef" class="col-lg-2 control-label">Test Definition</label>
             <div class="col-lg-10">
                 <select class="form-control" ng-model="test.def">
-                    <option ng-repeat="item in defs" value="{{item.release}}-schema:{{item.schema}}">{{item.release}}-schema:{{item.schema}}</option>
+                    <option ng-repeat="item in defs" value="{{item.release}}-schema:{{item.schema}}">{{item.release}}-schema:{{item.schema}} ({{item.count || 0}} drivers)</option>
                 </select>
                 <input type="checkbox" ng-model="showActiveTests" ng-checked="true" ng-change="showActiveTestDefs(showActiveTests)"> Active tests only
                 <span ng-show="nodefs"><i>(No active tests found)</i></span>


### PR DESCRIPTION
Updated TestCreateCtrl controller in benchmark-test.js and added a
default value for inactive test definitions, in create.html view.