### PR TITLE
Added test logs feature on summary page

### DIFF
--- a/server/src/main/webapp/benchmark/run/summary.html
+++ b/server/src/main/webapp/benchmark/run/summary.html
@@ -14,53 +14,95 @@
     </div>
 </div>
 <div class="row row-offcanvas row-offcanvas-right">
-    <div class="col-md-6 col-sm-12 col-xs-12">
-        <div class="panel panel-default">
-            <div class="panel-body">
-                <h3>
-                    {{summary.name}}
-                    <small ng-show="summary.description">,{{summary.description}}</small>
-                </h3>
-                <p>
-                    State: {{summary.state}}
-                </p>
-                <p ng-show="summary.scheduled != -1">
-                    Scheduled: {{summary.scheduled | date:'dd-MM-yyyy (HH:mm:ss)'}}
-                </p>
-                <p ng-show="summary.completed != -1">
-                    Completed: {{summary.completed | date:'dd-MM-yyyy (HH:mm:ss) '}}
-                </p>
-                <p ng-show="summary.duration != 0">
-                    Duration: {{summary.duration}} ms
-                </p>
-                <div>
-                    Progress:
-                    <div class="progress">
-                        <div class="progress-bar" role="progressbar" aria-valuenow="{{summary.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{summary.progress | number:2}}%;">
-                            {{summary.progress}}
-                        </div>
-                    </div>
-                </div>
-                <table>
-                  <tr>
-                    <td class="col-sm-5 text-right">
-                      <a ng-hide="summary.state != 'NOT_SCHEDULED' || hasStarted" id="startTestRunBtn-{{summary.name}}" ng-click="startRun()" class="btn">
-                                    <span class="fa fa-play fa-lg"></span>
-                                </a>
-                      <a href="#/tests/{{testname}}/{{summary.name}}/copy" class="btn" id="copyTestBtn-{{summary.name}}">
-                        <span class="fa fa-files-o fa-lg"></span>
-                        </a>
-                      <a class="btn" id="editTestBtn-{{testname}}" href="#/tests/{{testname}}/{{summary.name}}/properties">
-                        <span class="fa fa-cog fa-lg"></span>
-                      </a>
-                      <a ng-click="deleteRun()" class="btn" id="deleteTestBtn-{{summary.name}}">
-                        <span class="fa fa-trash-o fa-lg"></span>
-                      </a>
-                    </td>
-                  </tr>
-                </table>
-            </div>
-        </div>
+    <div class="col-md-8 col-sm-12 col-xs-12">
+	   	<!-- Nav tabs -->
+		<ul class="nav nav-tabs" id="summary-tabs">
+			<li class="active">
+			<a href="#/tests/{{testname}}/{{summary.name}}/#summary"
+				data-toggle="tab" onclick="return false;"><b>Summary</b></a></li>
+			<li><a href="#/tests/{{testname}}/{{summary.name}}/#logs" data-toggle="tab" onclick="return false;"><b>Logs</b> 
+				<span ng-if="errorLogs > 0" class="badge" style="background-color: red">{{errorLogs}}</span></a>
+			</li>
+		</ul>
+		<!-- Tab panes -->
+		<div class="tab-content">
+			<div class="tab-pane fade in active" id="summary">
+				</br>
+		        <div class="panel panel-default">
+		            <div class="panel-body">
+		                <h3>
+		                    {{summary.name}}
+		                    <small ng-show="summary.description">,{{summary.description}}</small>
+		                </h3>
+		                <p>
+		                    State: {{summary.state}}
+		                </p>
+		                <p ng-show="summary.scheduled != -1">
+		                    Scheduled: {{summary.scheduled | date:'dd-MM-yyyy (HH:mm:ss)'}}
+		                </p>
+		                <p ng-show="summary.completed != -1">
+		                    Completed: {{summary.completed | date:'dd-MM-yyyy (HH:mm:ss) '}}
+		                </p>
+		                <p ng-show="summary.duration != 0">
+		                    Duration: {{summary.duration}} ms
+		                </p>
+		                <div>
+		                    Progress:
+		                    <div class="progress">
+		                        <div class="progress-bar" role="progressbar" aria-valuenow="{{summary.progress}}" aria-valuemin="0" aria-valuemax="100" style="width: {{summary.progress | number:2}}%;">
+		                            {{summary.progress}}
+		                        </div>
+		                    </div>
+		                </div>
+		                <table>
+		                  <tr>
+		                    <td class="col-sm-5 text-right">
+		                      <a ng-hide="summary.state != 'NOT_SCHEDULED' || hasStarted" id="startTestRunBtn-{{summary.name}}" ng-click="startRun()" class="btn">
+		                                    <span class="fa fa-play fa-lg"></span>
+		                                </a>
+		                      <a href="#/tests/{{testname}}/{{summary.name}}/copy" class="btn" id="copyTestBtn-{{summary.name}}">
+		                        <span class="fa fa-files-o fa-lg"></span>
+		                        </a>
+		                      <a class="btn" id="editTestBtn-{{testname}}" href="#/tests/{{testname}}/{{summary.name}}/properties">
+		                        <span class="fa fa-cog fa-lg"></span>
+		                      </a>
+		                      <a ng-click="deleteRun()" class="btn" id="deleteTestBtn-{{summary.name}}">
+		                        <span class="fa fa-trash-o fa-lg"></span>
+		                      </a>
+		                    </td>
+		                  </tr>
+		                </table>
+		            </div>
+		        </div>
+		       </div>
+		       <div class="tab-pane fade" id="logs">
+				</br>
+				<div class="panel panel-info">
+					<div class="panel-heading">Logs</div>
+					<div style="overflow: scroll; height: 400px;" border: 10px>
+						<table class="table table-striped table-hover">
+							<thead>
+								<tr>
+									<th>Time</th>
+									<th data-align="center">Level</th>
+									<th data-align="left">Message</th>
+								</tr>
+							</thead>
+							<tr ng-repeat="log in logs">
+								<td stype="width: 40px;">{{log.time.$date }}</td>
+								<td ng-if="log.level==0">TRACE</td>
+								<td ng-if="log.level==1">DEBUG</td>
+								<td ng-if="log.level==2">INFO</td>
+								<td ng-if="log.level==3">WARN</td>
+								<td ng-if="log.level==4">ERROR</td>
+								<td ng-if="log.level==5">FATAL</td>
+								<td ng-style="log.level === 4 && {'color': 'red'}">{{log.msg }}</td>	
+							</tr>
+						</table>
+					</div>
+				</div>
+			</div>
+	      </div>
     </div>
     <!-- donut (refresh issue, click )
     <div class="col-md-6 col-sm-12 col-xs-12">

--- a/server/src/main/webapp/css/main.css
+++ b/server/src/main/webapp/css/main.css
@@ -98,3 +98,24 @@ donut-chart {
     font-size: 24px;
     font-weight: bold;
 }
+
+* tab colors */
+.nav-tabs>li>a {
+  background-color: #ffffff; 
+  border-color: #ffffff;
+  color:#000000;
+}
+
+/* active tab color */
+.nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus {
+  color: #000000;
+  background-color: #d8dddf;
+  border: 1px solid #888888;
+}
+
+/* hover tab color */
+.nav-tabs>li>a:hover {
+  border-color: #000000;
+  background-color: #d9edf7;
+}
+


### PR DESCRIPTION
A new nav tab is now available on the summary page with two tabs:
* first tab active with the test summary information
* 2nd tab with the actual test logs

(css also available